### PR TITLE
def11.5G.7 test's monitoring payload is now received via POST

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -2,7 +2,7 @@
 # @Author: Rafael Direito
 # @Date:   2023-05-22 10:53:45
 # @Last Modified by:   Eduardo Santos
-# @Last Modified time: 2023-12-31 18:42:45
+# @Last Modified time: 2024-01-05 19:31:32
 from fastapi import FastAPI, Path, Response, status, Depends
 from fastapi.responses import JSONResponse, FileResponse
 from fastapi.encoders import jsonable_encoder
@@ -81,6 +81,7 @@ async def configure(payload: schemas.Configuration):
 @app.post("/start/{operation_id}")
 async def start_test(
     operation_id: str,
+    monitoring_payload: dict = None,
     is_server: bool = False,
     target_ip: str = None,
     target_port: int = None,
@@ -311,7 +312,8 @@ async def start_test(
                 ip=variables.VARIABLES["NEF_IP"],
                 port=variables.VARIABLES["NEF_PORT"],
                 callback_url=variables.VARIABLES["SUBS1_CALLBACK_URL"],
-                token = variables.VARIABLES["AUTH_TOKEN"]
+                token = variables.VARIABLES["AUTH_TOKEN"],
+                monitoring_payload = monitoring_payload
             )
             return JSONResponse(content="QoS Subscription Done", status_code=200)
 

--- a/src/nef_operations/operations.py
+++ b/src/nef_operations/operations.py
@@ -2,7 +2,7 @@
 # @Author: Rafael Direito
 # @Date:   2023-05-22 11:40:10
 # @Last Modified by:   Eduardo Santos
-# @Last Modified time: 2023-12-31 18:42:56
+# @Last Modified time: 2024-01-05 19:32:09
 import requests
 import json 
 
@@ -230,7 +230,7 @@ def get_ue_handover_event(ip, port, ue_supi, token):
     if response.status_code not in [200, 201, 409]:
         response.raise_for_status()
 
-def subscribe_qos_event (ip, port, callback_url, token):
+def subscribe_qos_event (ip, port, callback_url, token, monitoring_payload):
 
     url = f"http://{ip}:{port}/nef/api/v1/3gpp-as-session-with-qos/" \
         "v1/netapp/subscriptions"
@@ -239,41 +239,6 @@ def subscribe_qos_event (ip, port, callback_url, token):
     headers["accept"] = "application/json"
     headers["Authorization"] = "Bearer " + token
     headers["Content-Type"] = "application/json"
-    
-    monitoring_payload = {
-        "ipv4Addr": "10.0.0.0",
-        "ipv6Addr": "0:0:0:0:0:0:0:0",
-        "macAddr": "22-00-00-00-00-00",
-        "notificationDestination": callback_url,
-        "snssai": {
-            "sst": 1,
-            "sd": "000001"
-        },
-        "dnn": "province1.mnc01.mcc202.gprs",
-        "qosReference": 9,
-        "altQoSReferences": [
-            0
-        ],
-        "usageThreshold": {
-            "duration": 0,
-            "totalVolume": 0,
-            "downlinkVolume": 0,
-            "uplinkVolume": 0
-        },
-        "qosMonInfo": {
-            "reqQosMonParams": [
-            "DOWNLINK"
-            ],
-            "repFreqs": [
-            "EVENT_TRIGGERED"
-            ],
-            "latThreshDl": 0,
-            "latThreshUl": 0,
-            "latThreshRp": 0,
-            "waitTime": 0,
-            "repPeriod": 0
-        }
-    }
 
     response = requests.post(
         url=url,

--- a/src/nef_operations/operations.py
+++ b/src/nef_operations/operations.py
@@ -103,8 +103,9 @@ def get_ues(ip, port, token):
         response.raise_for_status()
 
 
-def subscribe_event (ip, port, callback_url, monitoring_type,
-                     monitoring_expire_time, token):
+def subscribe_event(
+    ip, port, callback_url, monitoring_type, monitoring_expire_time, token
+):
 
     url = f"http://{ip}:{port}/nef/api/v1/3gpp-monitoring-event/" \
         "v1/netapp/subscriptions"


### PR DESCRIPTION
The def11.5G.7 test now receives the monitoring payload from the CICD LTR through the POST request.

This PR is linked to https://github.com/5gasp/CICD_LTR/pull/31

Closes #14 
